### PR TITLE
Fix broken first-time post crawling for non-first blog.

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -119,7 +119,7 @@ def add_blog(request):
                 for post in crawled:
                     post_url, post_title, post_date = post
                     Post.objects.create(
-                        blog=Blog.objects.get(user=request.user.id),
+                        blog=blog,
                         url=post_url,
                         title=post_title,
                         content="",


### PR DESCRIPTION
This would previously fail with `MultipleObjectsReturned` exception,
which was being caught silently.