### PR TITLE
Change Hacker School API root to reflect name change

### DIFF
--- a/home/oauth.py
+++ b/home/oauth.py
@@ -102,7 +102,7 @@ def update_user_details(hacker_id, user):
 class HackerSchoolOAuth2(BaseOAuth2):
     """HackerSchool.com OAuth2 authentication backend"""
     name = 'hackerschool'
-    HACKER_SCHOOL_ROOT = 'https://www.hackerschool.com'
+    HACKER_SCHOOL_ROOT = 'https://www.recurse.com'
     AUTHORIZATION_URL = HACKER_SCHOOL_ROOT + '/oauth/authorize'
     ACCESS_TOKEN_URL = HACKER_SCHOOL_ROOT + '/oauth/token'
     ACCESS_TOKEN_METHOD = 'POST'


### PR DESCRIPTION
We thought we could switch to recurse.com without breaking existing OAuth clients, but that turned out not to be the case. =( Really sorry!

This updates `HACKER_SCHOOL_ROOT` to reflect our new domain.

(We haven't tested this, but we're pretty sure that this should be the only change required.)