### PR TITLE
Ignore CharacterEncodingOverride exception when parsing.

### DIFF
--- a/home/feedergrabber27.py
+++ b/home/feedergrabber27.py
@@ -60,7 +60,7 @@ def find_feed_url(parsed_content):
         if link.get('type', '') in ('application/atom+xml', 'application/rss+xml'):
             return link.href
 
-def feedergrabber(url=None):
+def feedergrabber(url=None, suggest_feed_url=False):
     """The main function of the module."""
 
     # Initial checks on the URL.
@@ -82,7 +82,7 @@ def feedergrabber(url=None):
         return None, errors
 
     elif file_contents.bozo and not isinstance(file_contents.bozo_exception, feedparser.CharacterEncodingOverride):
-        feed_url = find_feed_url(file_contents)
+        feed_url = find_feed_url(file_contents) if suggest_feed_url else None
         return None, [{'feed_url': feed_url, 'url': url, 'error': file_contents.bozo_exception}]
 
     # Gather links, titles, and dates

--- a/home/feedergrabber27.py
+++ b/home/feedergrabber27.py
@@ -79,11 +79,11 @@ def feedergrabber(url=None):
     file_contents, _ = retrieve_file_contents(url, errors)
 
     if file_contents is None:
-        return None, None
+        return None, errors
 
-    elif file_contents.bozo:
+    elif file_contents.bozo and not isinstance(file_contents.bozo_exception, feedparser.CharacterEncodingOverride):
         feed_url = find_feed_url(file_contents)
-        return None, [{'feed_url': feed_url, 'url': url}]
+        return None, [{'feed_url': feed_url, 'url': url, 'error': file_contents.bozo_exception}]
 
     # Gather links, titles, and dates
     for i in file_contents.entries:

--- a/home/management/commands/crawlposts.py
+++ b/home/management/commands/crawlposts.py
@@ -48,6 +48,7 @@ class Command(NoArgsCommand):
         crawled, errors = feedergrabber27.feedergrabber(blog.feed_url)
 
         if crawled:
+            log.debug('Crawled %s blogs from %s', len(crawled), blog.feed_url)
             post_count = 0
             for link, title, date in crawled:
 
@@ -58,7 +59,7 @@ class Command(NoArgsCommand):
                 post, created = get_or_create_post(blog, title, link, date)
 
                 if created:
-                    print "Created '%s' from blog '%s'" % (title, blog.feed_url)
+                    log.debug("Created '%s' from blog '%s'", title, blog.feed_url)
 
                     # Throttle the amount of new posts that can be announced per user per crawl.
                     if post_count < MAX_POST_ANNOUNCE:

--- a/home/views.py
+++ b/home/views.py
@@ -111,7 +111,7 @@ def add_blog(request):
             # Feedergrabber returns ( [(link, title, date)], [errors])
             # We're not handling the errors returned for right now
             # Returns None if there was an exception when parsing the content.
-            crawled, errors = feedergrabber27.feedergrabber(feed_url)
+            crawled, errors = feedergrabber27.feedergrabber(feed_url, suggest_feed_url=True)
             if crawled is None:
                 message = (
                     "This url does not seem to contain valid atom/rss feed xml. "


### PR DESCRIPTION
It should be treated more like a warning than an exception, but `feedparser` sets `bozo` attribute and this caused an issue with parsing some blogs. 